### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Tamper is based on the awesome Mitmproxy (man-in-the-middle proxy), or more prec
 
 * Install Tamper's python script
 ```
-pip install tamper
+sudo pip install tamper
 ```
 * Install [Tamper's devtools extension](https://chrome.google.com/webstore/detail/tamper/mabhojhgigkmnkppkncbkblecnnanfmd)
 


### PR DESCRIPTION
pip tamper should be install with admin rights because some other dependencies during installation though error, and already some users have reported similar issues.
