### PR TITLE
Fix compatibility with Linux

### DIFF
--- a/chrome-extension/app/manifest.json
+++ b/chrome-extension/app/manifest.json
@@ -24,7 +24,7 @@
     "commands": {
         "toggle-tamper": {
             "suggested_key": {
-                "windows": "Ctrl+Shift+P",
+                "default": "Ctrl+Shift+P",
                 "mac": "Command+Shift+P"
             },
             "description": "Toggle Tamper"


### PR DESCRIPTION
Alternative fix is to include `"linux": "Ctrl+Shift+P"`. But as it equals to
the one specified for windows, IMO it's better to simply specify `default`
instead.

This will also fix manifest for all `!(windows|macos)` users in general. :D