### PR TITLE
Adds linux-support

### DIFF
--- a/chrome-extension/app/manifest.json
+++ b/chrome-extension/app/manifest.json
@@ -25,6 +25,7 @@
         "toggle-tamper": {
             "suggested_key": {
                 "windows": "Ctrl+Shift+P",
+                "linux": "Ctrl+Shift+P",
                 "mac": "Command+Shift+P"
             },
             "description": "Toggle Tamper"


### PR DESCRIPTION
Without this change, I'd get the following error message when
trying to install the chrome-extension:

## Error message

> Could not find key specification for 'command[1].suggested_key':
> Either specific a key for 'linux', or speify a default key.