### PR TITLE
Added an entry for linux within 'suggested_key'

### DIFF
--- a/chrome-extension/app/manifest.json
+++ b/chrome-extension/app/manifest.json
@@ -25,7 +25,8 @@
         "toggle-tamper": {
             "suggested_key": {
                 "windows": "Ctrl+Shift+P",
-                "mac": "Command+Shift+P"
+                "mac": "Command+Shift+P",
+                "linux": "Ctrl+Shift+P"
             },
             "description": "Toggle Tamper"
         }


### PR DESCRIPTION
This omission causes the extension to fail on installation both from webstore and locally.