### PR TITLE
Make setup.py compatible with python 2 and 3

### DIFF
--- a/mitmproxy-extension/setup.py
+++ b/mitmproxy-extension/setup.py
@@ -57,8 +57,8 @@ class PostInstallScript(install):
 			    os.makedirs(manifestFilename)
 
 			manifestFilename = manifestFilename + 'com.dutzi.tamper.json'
-			print '\nWriting chrome native messaging manifest file (' + manifestFilename + ')'
-			print sys.prefix
+			print('\nWriting chrome native messaging manifest file (%s)' % manifestFilename)
+			print(sys.prefix)
 
 			manifestFile = open(manifestFilename, 'w')
 			json.dump(nativeMessagingManifest, manifestFile, sort_keys=True, indent=4)


### PR DESCRIPTION
In python2, we can put the expressions to be printed in parentheses to
make `print` look like a function call, which is how it's used in
python3.  So surrounding these expressions in parentheses make
`setup.py` compatible to both versions of python.

This fixes issue #34 